### PR TITLE
fix typo in documentation

### DIFF
--- a/Example.ipynb
+++ b/Example.ipynb
@@ -19,7 +19,7 @@
     "- Tests can be executed with the `%%ipytest` magic\n",
     "- The `pytest` assert rewriting system to get nice assert messages will integrated into the notebook \n",
     "\n",
-    "For more control, pass the relevant arguments to `ipytest.autconfig()`. For details, see the documentation in the readme."
+    "For more control, pass the relevant arguments to `ipytest.autoconfig()`. For details, see the documentation in the readme."
    ]
   },
   {

--- a/Readme.md
+++ b/Readme.md
@@ -100,7 +100,7 @@ ipytest.autoconfig(raise_on_error=True)
 filename that is associated with the notebook is passed. There are a number of
 ways to configure this behavior:
 
-- `ipytest.config(addopts=...)` or `ipytest.autconfig(addopts=...)` allow to
+- `ipytest.config(addopts=...)` or `ipytest.autoconfig(addopts=...)` allow to
   specify a list of strings that are added to the command line. For example,
   `ipytest.autoconfig(addopts=["-x", "--pdb"])` will attach the debugger on the
   first test failure and not run further tests.


### PR DESCRIPTION
A couple places refer to `ipytest.autconfig` instead of `ipytest.autoconfig`. That confused me for a little bit when I first read it, so I fixed it.